### PR TITLE
Implement cascading delete for ProductoEntidad when deleting Producto

### DIFF
--- a/SBRSystem-API/GraphQl/Mutation/BpmInpeccionMutation.cs
+++ b/SBRSystem-API/GraphQl/Mutation/BpmInpeccionMutation.cs
@@ -227,7 +227,7 @@ public class BpmInpeccionMutation
            ProduccionAnual = input.ProduccionAnual,
            Comercializacion = input.Comercializacion,
            MercadoObjetivoId = input.MercadoObjetivo_id,
-           NumEmpleados = input.NumEmpleados,
+            NumEmpleados = input.NumEmpleados,
            UltimaInspeccion = input.UltimaInspeccion,
            CalUltimaInspeccion = input.CalUltimaInspeccion,
            NombreDps = input.NombreDps,
@@ -252,9 +252,4 @@ public class BpmInpeccionMutation
            x.Rnc== input.Rnc);
 
    }
-   
-   
-   
-   
-   
 }

--- a/SBRSystem-API/GraphQl/Mutation/ProductoMutation.cs
+++ b/SBRSystem-API/GraphQl/Mutation/ProductoMutation.cs
@@ -9,12 +9,11 @@ namespace SBRSystem_API.GraphQl.Mutation;
 [MutationType]
 public class ProductoMutation
 {
-    public async Task<Producto> AddProductoAsync(AddProductoInput input,
-        [Service] MySBRDbContext context)
+    public async Task<Producto> AddProductoAsync(AddProductoInput input, [Service] MySBRDbContext context)
     {
         if (await context.Productos.AnyAsync(p => p.Nombre == input.Nombre))
         {
-            throw new GraphQLException("El riesgo ya existe");
+            throw new GraphQLException("El producto ya existe");
         }
 
         var newProducto = new Producto
@@ -24,55 +23,51 @@ public class ProductoMutation
             Origen = input.Origen,
             Estado = input.Estado,
             Presentaciones = input.Presentaciones,
-            EstadoFisicoId= input.EstadoFisicoId,
+            EstadoFisicoId = input.EstadoFisicoId,
             EnvasePrimario = input.EnvasePrimario,
             MaterialEmpaque = input.MaterialEmpaque,
             Nacional = input.Nacional,
-            UnIngrediente = input.UnIngrediente
+            UnIngrediente = input.UnIngrediente,
         };
-        
+
         context.Productos.Add(newProducto);
 
         try
         {
+            await context.SaveChangesAsync();
 
+            foreach (var productoEntidad in input.ProductoEntidades)
+            {
+                productoEntidad.ProductoId = newProducto.ProductoId;
+                context.ProductoEntidads.Add(productoEntidad);
+            }
+
+            await context.SaveChangesAsync();
         }
         catch (Exception ex)
         {
-            Log.Error($"Ocurrio un error tratando de introducir datos en la base de datos. \n Error Mesagge: {ex.Message}");
+            Log.Error(
+                $"Ocurrio un error tratando de introducir datos en la base de datos. \n Error Mesagge: {ex.Message}");
             throw new GraphQLException("Ocurrio un error al tratar de agregar un producto", ex);
         }
-        
+
         return newProducto;
     }
 
-    public async Task<Producto> DeleteProducto(DeleteProductoInput input, [Service] MySBRDbContext context)
+    public async Task<bool> DeleteProductoAsync(int productoId, [Service] MySBRDbContext context)
     {
-        var producto = await context.Productos.FindAsync(input.ProductoId);
+        var producto = await context.Productos
+            .Include(p => p.ProductoEntidads)
+            .FirstOrDefaultAsync(p => p.ProductoId == productoId);
 
         if (producto == null)
         {
-            Log.Error("Producto no encontrado");
-            throw new GraphQLException("El producto no existe");
+            throw new GraphQLException("Producto not found");
         }
 
-        if (producto.Estado == "false")
-        {
-            Log.Error("El producto ya fue eliminado");
-        }
-        
-        producto.Estado = "false";
+        context.Productos.Remove(producto);
+        await context.SaveChangesAsync();
 
-        try
-        {
-
-        }
-        catch (DbUpdateException ex)
-        {
-            Log.Error($"Error al eliminar el producto{ex}");
-            throw new GraphQLException($"Error al tratar de eliminar el producto{ex}");
-        }
-
-        return producto;
+        return true;
     }
 }

--- a/SBRSystem-API/GraphQl/input/ProductoInput.cs
+++ b/SBRSystem-API/GraphQl/input/ProductoInput.cs
@@ -1,3 +1,5 @@
+using SBRSystem_Data.Models;
+
 namespace SBRSystem_API.GraphQl.input;
 
 public class AddProductoInput
@@ -24,6 +26,9 @@ public class AddProductoInput
     public bool? Nacional{ get; set; }
     [GraphQLNonNullType]
     public bool? UnIngrediente{ get; set; }
+
+    public ICollection<ProductoEntidad> ProductoEntidades{get;set;}
+
 }
 
 


### PR DESCRIPTION
### Description

This pull request implements cascading delete and mutliple entities adding functionality for `ProductoEntidad` when deleting a `Producto`.

### Changes

- **Updated `DeleteProductoAsync` method in `ProductoMutation`:**
    - Included related `ProductoEntidad` entries to ensure they are deleted when a `Producto` is deleted.

- **Updated `AddProductoAsync` method in `ProductoMutation`:**
    - Included related 'ProductoEntidad' entries to ensure added when a product is added 

- **Ensured cascading delete configuration in `OnModelCreating` method of `MySBRDbContext`:**
    - Configured the `ProductoEntidad` entity to cascade delete when a related `Producto` is removed.

### Related Files

- `SBRSystem-API/GraphQl/Mutation/ProductoMutation.cs`
- `SBRSystem-Data/Context/MySBRDbContext.cs`
- `SBRSystem-Data/Models/Producto.cs`
- `SBRSystem-Data/Models/ProductoEntidad.cs`

### Branch

- **Current branch name:** `6-proceso-de-producto-a-entidad`

### Repository

- **Upstream name and URL:** `origin - https://github.com/SBR-2/SBR-backend.git`
